### PR TITLE
Feature - Add current ongoing events list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ This bot works either with `!` or `$` prefixes.
 ```
 !birthday_announcements general
 ```
+- **current_events**: Returns a list with the different current ongoing events in all Re-live servers.
+These events are classified as _events_, _challenges_ and _score attack_ (bosses).
+
+```
+!current_events
+```
 
 ### Tasks ###
 

--- a/coverage.svg
+++ b/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#fe7d37" d="M63 0h36v20H63z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">59%</text>
-        <text x="80" y="14">59%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">61%</text>
+        <text x="80" y="14">61%</text>
     </g>
 </svg>

--- a/settings.json
+++ b/settings.json
@@ -3,7 +3,8 @@
   "prefixes":  ["!", "$"],
   "commands": [
     "command.birthday.birthday",
-    "command.configuration.configuration"
+    "command.configuration.configuration",
+    "command.event.event"
   ],
   "karthuria_api_url": "https://karth.top/api",
   "servers_path": "servers.json"

--- a/src/command/birthday/birthday.py
+++ b/src/command/birthday/birthday.py
@@ -9,6 +9,7 @@ from command.configuration.repository.server_repository import ServerRepository
 from command.initializer import Initializer
 from karthuria.repository.character_repository import CharacterRepository
 from utils.date_utils import convert_date_to_str
+from utils.discord_utils import get_discord_color
 
 LOG_ID = "BirthdayCommand"
 logging.basicConfig(level=logging.INFO)
@@ -120,16 +121,6 @@ def special_message_birthday(name: str) -> str:
     if 'maya' in name.lower():
         message = 'Jum! That annoying woman birthday is'
     return message
-
-
-def get_discord_color(color: tuple) -> discord.Color:
-    """
-    Given a tuple of rgb colors from each character, return the respective Discord color for it.
-
-    :param color: A tuple with the r, g, b values
-    :return: A discord Color value based on the given values
-    """
-    return discord.Color.from_rgb(color[0], color[1], color[2])
 
 
 def setup(my_bot: commands.Bot) -> None:

--- a/src/command/birthday/birthday.py
+++ b/src/command/birthday/birthday.py
@@ -64,7 +64,7 @@ class BirthdayCommand(commands.Cog):
         :return: None
         """
         logging.info('[{0}] - Reviewing today birthdays'.format(LOG_ID))
-        self.server_repository.load_servers()
+        self.server_repository.reload_servers()
         today = convert_date_to_str(datetime.today().date(), '%d/%m')
         birthday_girl = self.character_repository.get_character_birthday(today)
 

--- a/src/command/birthday/birthday.py
+++ b/src/command/birthday/birthday.py
@@ -46,10 +46,10 @@ class BirthdayCommand(commands.Cog):
         character = self.character_repository.get_character_by_name(name)
         if character:
             title = 'Birthday of {0}'.format(character.name)
-            message = '{0} {1}'.format(_special_message_birthday(character.name),
+            message = '{0} {1}'.format(special_message_birthday(character.name),
                                        convert_date_to_str(character.birthday))
             rgb = character.color.rgb
-            embed = discord.Embed(title=title, description=message, color=_get_discord_color(rgb))
+            embed = discord.Embed(title=title, description=message, color=get_discord_color(rgb))
             embed.set_thumbnail(url=character.portrait)
         else:
             message = "Je suis désolé, I don't know who '{0}' is".format(name)
@@ -76,7 +76,7 @@ class BirthdayCommand(commands.Cog):
             message = "@everyone Today is {0} birthday!! Let's celebrate it.".format(pronoun)
             rgb = birthday_girl.color.rgb
 
-            embed = discord.Embed(title=title, description=message, color=_get_discord_color(rgb))
+            embed = discord.Embed(title=title, description=message, color=get_discord_color(rgb))
             embed.set_thumbnail(url=birthday_girl.portrait)
             embed.set_image(url=SCHOOL_ICON_URL.format(birthday_girl.school))
             embed.add_field(name='Description', value=birthday_girl.description, inline=False)
@@ -105,7 +105,7 @@ class BirthdayCommand(commands.Cog):
         logging.info('[{0}] - Birthday reminders ready!'.format(LOG_ID))
 
 
-def _special_message_birthday(name: str) -> str:
+def special_message_birthday(name: str) -> str:
     """
     Retrieve an special birthday message based on which character was queried.
 
@@ -122,7 +122,7 @@ def _special_message_birthday(name: str) -> str:
     return message
 
 
-def _get_discord_color(color: tuple) -> discord.Color:
+def get_discord_color(color: tuple) -> discord.Color:
     """
     Given a tuple of rgb colors from each character, return the respective Discord color for it.
 

--- a/src/command/configuration/repository/server_repository.py
+++ b/src/command/configuration/repository/server_repository.py
@@ -45,9 +45,9 @@ class ServerRepository:
             server = Server(server_id, server_name)
         add_channel = getattr(server, 'add_{0}'.format(channel_type.value))
         add_channel(channel)
-        self._save_server(server)
+        self.__save_server(server)
 
-    def _save_server(self, new_server: Server) -> None:
+    def __save_server(self, new_server: Server) -> None:
         """
         Saves into a pre configured json file the information of a server.
         If the server already exist then it will update it.

--- a/src/command/configuration/repository/server_repository.py
+++ b/src/command/configuration/repository/server_repository.py
@@ -16,7 +16,7 @@ class ServerRepository:
 
     def __init__(self, servers_path: str):
         self.file_path = servers_path
-        self.servers = self.load_servers()
+        self.servers = self.__load_servers()
 
     def find_server_by_id(self, server_id: int) -> Server:
         """
@@ -71,7 +71,7 @@ class ServerRepository:
         except (TypeError, FileNotFoundError) as error:
             logging.error("[{0}] - Couldn't saver server [{1}] information: {2}".format(LOG_ID, new_server.name, error))
 
-    def load_servers(self) -> list:
+    def __load_servers(self) -> list:
         """
         Load server information from a file if exists otherwise will return an empty list
         :return: A list with the server information
@@ -88,6 +88,15 @@ class ServerRepository:
         except (JSONDecodeError, TypeError) as error:
             logging.error("[{0}] - Couldn't load server information: {1}".format(LOG_ID, error))
         return servers
+
+    def reload_servers(self) -> None:
+        """
+        Refresh the current server information of the file into the ServerRepository.
+        This is a measure to keep data updated.
+
+        :return: None
+        """
+        self.servers = self.__load_servers()
 
 
 def convert_to_server(server_dict: dict) -> Server:

--- a/src/command/event/event.py
+++ b/src/command/event/event.py
@@ -1,0 +1,128 @@
+import logging
+
+import discord
+from discord.ext import commands
+from discord.ext.commands import Context
+
+from command.initializer import Initializer
+from karthuria.repository.dress_repository import DressRepository
+from karthuria.repository.enemy_repository import EnemyRepository
+from karthuria.repository.event_repository import EventRepository
+from utils.discord_utils import get_discord_color
+
+LOG_ID = "EventCommand"
+logging.basicConfig(level=logging.INFO)
+
+RELIVE_RGB = (234, 1, 36)
+
+
+class EventCommand(commands.Cog):
+    """
+    All Kuro bot discord commands that are related to events. Either to get list of current events or to notify them
+    """
+
+    def __init__(self, event_repository: EventRepository, dress_repository: DressRepository,
+                 enemy_repository: EnemyRepository, my_bot=commands.Bot):
+        self.bot = my_bot
+        self.event_repository = event_repository
+        self.dress_repository = dress_repository
+        self.enemy_repository = enemy_repository
+
+    @commands.command(pass_context=True)
+    async def current_events(self, ctx: Context):
+        """
+        Show a list with the name and end date of the ongoing events in all server of Relive.
+
+        :param ctx: Discord Context
+        :return: Message with the current events, challenges and bosses battles in relive
+        """
+        logging.debug('[{0}] - Current Events called with value'.format(LOG_ID))
+
+        bullets_emoji = ':white_small_square:'
+        message_format = '{0}{1} - {2} \n'
+        title = 'List of Current Ongoing Events'
+        description = 'This is what I could find:'
+        embed = discord.Embed(title=title, description=description, color=get_discord_color(RELIVE_RGB))
+
+        current_events = self.event_repository.get_current_events()
+
+        if 'events' in current_events:
+            events_message = ''
+
+            events = self.__get_complete_events_list(current_events['events'])
+            for event in events:
+                events_message += message_format.format(bullets_emoji, event.name, event.end_date)
+            embed.add_field(name='Events', value=events_message, inline=False)
+
+        if 'challenges' in current_events:
+            challenges_message = ''
+            challenges = self.__get_complete_challenges_list(current_events['challenges'])
+            for challenge in challenges:
+                challenges_message += message_format.format(bullets_emoji, challenge.name, challenge.end_date)
+            embed.add_field(name='Challenges Revue', value=challenges_message, inline=False)
+
+        if 'bosses' in current_events:
+            bosses_message = ''
+            bosses = self.__get_complete_bosses_list(current_events['bosses'])
+            for boss in bosses:
+                bosses_message += message_format.format(bullets_emoji, boss.name, boss.end_date)
+            embed.add_field(name='Score Attack Revue', value=bosses_message, inline=False)
+
+        await ctx.send(embed=embed)
+
+    def __get_complete_events_list(self, events: list) -> list:
+        """
+        Complete events information, like their name and returns a list with the events updated
+
+        :param events: List of current events
+        :return: A new list of events with its respective names
+        """
+        events_list = []
+        for event in events:
+            event_name = self.event_repository.get_event_name_by_id(event.event_id)
+            event.set_name(event_name if event_name is not None else 'NN')
+            events_list.append(event)
+        return events_list
+
+    def __get_complete_challenges_list(self, challenges: list) -> list:
+        """
+        Complete challenges information, like their name and returns a list with the challenges updated
+
+        :param challenges: List of current challenges
+        :return: A new list of challenges with its respective names
+        """
+        challenges_list = []
+        for challenge in challenges:
+            dress = self.dress_repository.get_dress_by_id(challenge.event_id)
+            dress_name = dress.name if dress is not None else 'NN'
+            challenge.set_name(dress_name)
+            challenges_list.append(challenge)
+        return challenges_list
+
+    def __get_complete_bosses_list(self, bosses: list) -> list:
+        """
+        Complete bosses information, like their name and returns a list with the bosses updated
+
+        :param bosses: List of current bosses
+        :return: A new list of bosses with its respective names
+        """
+        bosses_list = []
+        for boss in bosses:
+            enemy = self.enemy_repository.get_enemy_by_id(boss.event_id)
+            enemy_name = enemy.name if enemy is not None else 'NN'
+            boss.set_name(enemy_name)
+            bosses_list.append(boss)
+        return bosses_list
+
+
+def setup(my_bot: commands.Bot) -> None:
+    """
+    Bot setup necessary to recognize its COG
+    :param my_bot: the bot where the commands need to be register
+    :return: None
+    """
+    initializer = Initializer()
+    my_bot.add_cog(EventCommand(initializer.get_event_repository(),
+                                initializer.get_dress_repository(),
+                                initializer.get_enemy_repository(),
+                                my_bot))

--- a/src/command/initializer.py
+++ b/src/command/initializer.py
@@ -3,6 +3,9 @@ import os
 from command.configuration.repository.server_repository import ServerRepository
 from karthuria.client import KarthuriaClient
 from karthuria.repository.character_repository import CharacterRepository
+from karthuria.repository.dress_repository import DressRepository
+from karthuria.repository.enemy_repository import EnemyRepository
+from karthuria.repository.event_repository import EventRepository
 from utils.file_utils import load_json_file
 
 
@@ -30,6 +33,9 @@ class Initializer(metaclass=Singleton):
         self.karthuria_client = KarthuriaClient(self.settings.get('karthuria_api_url'))
         self.character_repository = CharacterRepository(self.karthuria_client)
         self.server_repository = ServerRepository(self.settings.get('servers_path'))
+        self.event_repository = EventRepository(self.karthuria_client)
+        self.dress_repository = DressRepository(self.karthuria_client)
+        self.enemy_repository = EnemyRepository(self.karthuria_client)
 
     def get_karthuria_client(self) -> KarthuriaClient:
         """
@@ -51,3 +57,24 @@ class Initializer(metaclass=Singleton):
         :return: An instance of the Server Repository
         """
         return self.server_repository
+
+    def get_event_repository(self) -> EventRepository:
+        """
+        Based on the class initialization return the specific event repository that was configured.
+        :return: An instance of the Event Repository
+        """
+        return self.event_repository
+
+    def get_dress_repository(self) -> DressRepository:
+        """
+        Based on the class initialization return the specific dress repository that was configured.
+        :return: An instance of the Dress Repository
+        """
+        return self.dress_repository
+
+    def get_enemy_repository(self) -> EnemyRepository:
+        """
+        Based on the class initialization return the specific enemy repository that was configured.
+        :return: An instance of the Event Repository
+        """
+        return self.enemy_repository

--- a/src/karthuria/client.py
+++ b/src/karthuria/client.py
@@ -1,6 +1,7 @@
 import requests
 
-from karthuria.model.character import Character
+from karthuria.model.character import Character, Dress, Enemy
+from karthuria.model.event import Event, Challenge, Boss
 
 
 class KarthuriaClient:
@@ -36,7 +37,7 @@ class KarthuriaClient:
 
         return list_of_characters if response.ok else response.raise_for_status()
 
-    def get_character(self, chara_id: int) -> dict:
+    def get_character(self, chara_id: int) -> Character:
         """
         Retrieve detailed information of one character based on if its given id
 
@@ -53,10 +54,90 @@ class KarthuriaClient:
 
         return convert_to_character(basic_info, info) if response.ok else response.raise_for_status()
 
+    def get_dress(self, dress_id: int) -> Dress:
+        """
+        Retrieve detailed information of one dress based on if its given id
+
+        :param dress_id: the identifier of the dress
+        :return: An object of Dress type with the detailed information
+        """
+        path = '/dress/{0}.json'.format(dress_id)
+        response = requests.get(self.endpoint + path)
+
+        if response.ok:
+            dress_json = response.json()
+            basic_info = dress_json['basicInfo']
+
+        return convert_to_dress(basic_info) if response.ok else response.raise_for_status()
+
+    def get_enemy(self, enemy_id: int) -> Enemy:
+        """
+        Retrieve detailed information of one enemy based on if its given id
+
+        :param enemy_id: the identifier of the dress
+        :return: An object of Enemy type with the detailed information
+        """
+        path = '/enemy/{0}_0.json'.format(enemy_id)
+        response = requests.get(self.endpoint + path)
+
+        if response.ok:
+            enemy_json = response.json()
+            basic_info = enemy_json['basicInfo']
+
+        return convert_to_enemy(basic_info) if response.ok else response.raise_for_status()
+
+    def get_events(self) -> list:
+        """
+        Get all existing events information.
+
+        :return: A list of Event with its id and name
+        """
+        path = '/event.json'
+        response = requests.get(self.endpoint + path)
+        events = []
+
+        if response.ok:
+            events_json = response.json()
+            for event in events_json:
+                name = events_json[event]['name']['en'] \
+                    if events_json[event]['name']['en'] is not None else events_json[event]['name']['ja']
+                events.append(Event(event, name=name))
+
+        return events if response.ok else response.raise_for_status()
+
+    def get_current_events(self) -> dict:
+        """
+        Retrieve basic information of current events.
+
+        :return: A dictionary with different type of active events, challenges or boss battles
+        """
+        path = '/event/ww/current.json'
+        response = requests.get(self.endpoint + path)
+        current_events = {}
+
+        if response.ok:
+            events_json = response.json()
+            if 'event' in events_json:
+                event_info = events_json['event']
+                events = [convert_to_event(event_info[event]) for event in event_info if event_info[event]['info'] != 0]
+                current_events['events'] = events
+            if 'rogue' in events_json:
+                rogue_info = events_json['rogue']
+                challenges = [convert_to_challenge(rogue_info[challenge]) for challenge in rogue_info]
+                current_events['challenges'] = challenges
+            if 'titan' in events_json:
+                titan_info = events_json['titan']
+                boss_end_at = titan_info['endAt']
+                bosses = [convert_to_boss(titan_info['enemy'][boss], boss_end_at) for boss in titan_info['enemy']]
+                current_events['bosses'] = bosses
+
+        return current_events if response.ok else response.raise_for_status()
+
 
 def convert_to_character(basic_info: dict, detailed_info: dict = None) -> Character:
     """
     Transform a dictionary with the 'basicInfo' and 'info' information returned by Karthuria API
+    into a Character object
 
     :param basic_info: Information retrieved from the 'basicInfo' response
     :param detailed_info: Information retrieved from the 'info' response of detailed character information
@@ -70,3 +151,79 @@ def convert_to_character(basic_info: dict, detailed_info: dict = None) -> Charac
                           basic_info['school_id'],
                           detailed_info=detailed_info)
     return character
+
+
+def convert_to_dress(basic_info: dict) -> Dress:
+    """
+    Transform a dictionary with the 'basicInfo' information returned by Karthuria API
+    into a Dress object
+
+    :param basic_info: Information retrieved from the 'basicInfo' response
+    :return: A new instance of the Dress model with the given information
+    """
+    name = basic_info['name']['en'] if 'en' in basic_info['name'] else basic_info['name']['ja']
+    dress = Dress(basic_info['cardID'],
+                  name,
+                  basic_info['rarity'])
+
+    return dress
+
+
+def convert_to_enemy(basic_info: dict) -> Enemy:
+    """
+    Transform a dictionary with the 'basicInfo' information returned by Karthuria API
+    into a Enemy object
+
+    :param basic_info: Information retrieved from the 'basicInfo' response
+    :return: A new instance of the Enemy model with the given information
+    """
+    name = basic_info['name']['en'] if basic_info['name']['en'] is not None else basic_info['name']['ja']
+    enemy = Enemy(int(basic_info['enemyID'].split('_', 1)[0]),
+                  name,
+                  basic_info['rarity'],
+                  basic_info['icon'])
+
+    return enemy
+
+
+def convert_to_event(event_info: dict) -> Event:
+    """
+    Transform a dictionary with the 'event' information returned by Karthuria API into a Event object
+
+    :param event_info: Information retrieved from the 'event' response
+    :return: A new instance of the Event model with the given information
+    """
+    event = Event(event_info['id'],
+                  end_date=event_info['endAt'][0],
+                  start_date=event_info['beginAt'][0])
+
+    return event
+
+
+def convert_to_challenge(challenge_info: dict) -> Challenge:
+    """
+    Transform a dictionary with the 'rogue' information returned by Karthuria API into a Challenge object
+
+    :param challenge_info: Information retrieved from the 'rogue' response
+    :return: A new instance of the Challenge model with the given information
+    """
+    challenge = Challenge(challenge_info['id'],
+                          challenge_info['endAt'],
+                          start_date=challenge_info['beginAt'])
+
+    return challenge
+
+
+def convert_to_boss(boss_info: dict, end_at: int) -> Boss:
+    """
+    Transform a dictionary with the 'titan' and 'enemy' information returned by Karthuria API into a Boss object
+
+    :param boss_info: Information retrieved from the 'titan' and 'enemy' response
+    :param end_at: End date of the boss battle
+    :return: A new instance of the Boss model with the given information
+    """
+    boss = Boss(boss_info['id'],
+                end_at,
+                hp_percentage=boss_info['hpLeftPercent'])
+
+    return boss

--- a/src/karthuria/model/character.py
+++ b/src/karthuria/model/character.py
@@ -7,7 +7,7 @@ PORTRAIT_URL = 'https://api.karen.makoo.eu/api/assets/jp/res/ui/images/archive/a
 
 class Character:
     """
-    Model class of the basic information that can be retrieved from the Karthuria API
+    Model class of a Character with the basic information that can be retrieved from the Karthuria API
     """
 
     def __init__(self, chara_id, name, birth_day, birth_month, school_id, detailed_info=None):
@@ -22,3 +22,26 @@ class Character:
             self.seiyuu = detailed_info['cv']['en']
             self.likes = detailed_info['likes']['en']
             self.dislikes = detailed_info['dislikes']['en']
+
+
+class Dress:
+    """
+    Model class of Dress with the basic information that can be retrieved from the Karthuria API
+    """
+
+    def __init__(self, dress_id: int, name: str, rarity: int):
+        self.dress_id = dress_id
+        self.name = name
+        self.rarity = rarity
+
+
+class Enemy:
+    """
+    Model class of Enemy with the basic information that can be retrieved from the Karthuria API
+    """
+
+    def __init__(self, enemy_id: id, name: str, rarity: int, icon: int):
+        self.enemy_id = enemy_id
+        self.name = name
+        self.rarity = rarity
+        self.icon = icon

--- a/src/karthuria/model/event.py
+++ b/src/karthuria/model/event.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+
+
+class Event:
+    """
+    Model class of Events information that can be retrieve from Karthuria API
+    """
+
+    EVENT_BANNER_URL = 'https://api.karen.makoo.eu/api/assets/ww/res_en/res/event_permanent/banner/event_banner_{0}.png'
+
+    def __init__(self, event_id: int, end_date: int = None, name: str = None, start_date: int = None):
+        self.event_id = event_id
+        self.name = name
+        self.start_date = datetime.fromtimestamp(start_date) if start_date is not None else start_date
+        self.end_date = datetime.fromtimestamp(end_date) if end_date is not None else end_date
+        self.icon = self.EVENT_BANNER_URL.format(event_id)
+
+    def set_start_date(self, start_date: int) -> None:
+        self.start_date = datetime.fromtimestamp(start_date)
+
+    def set_end_date(self, end_date: int) -> None:
+        self.end_date = datetime.fromtimestamp(end_date)
+
+    def set_name(self, name: str) -> None:
+        self.name = name
+
+
+class Challenge(Event):
+    """
+    Model class of Challenge information that can be retrieve from Karthuria API
+    """
+
+    CHALLENGE_ICON_URL = 'https://api.karen.makoo.eu/api/assets/jp/res/item_root/large/1_{0}.png'
+
+    def __init__(self, challenge_id: int, end_date: int, name: str = None, rarity: int = None, start_date: int = None):
+        super().__init__(challenge_id, end_date, name, start_date)
+        self.icon = self.CHALLENGE_ICON_URL.format(challenge_id)
+        self.rarity = rarity
+
+    def set_rarity(self, rarity: int) -> None:
+        self.rarity = rarity
+
+
+class Boss(Event):
+    """
+    Model class of Enemy information that can be retrieve from Karthuria API
+    """
+
+    ENEMY_ICON_URL = 'https://api.karen.makoo.eu/api/assets/jp/res/icon/enemy/{0}.png'
+
+    def __init__(self, boss_id: int, end_date: int, name: str = None, rarity: int = None, hp_percentage: str = None):
+        super().__init__(boss_id, end_date, name, None)
+        self.icon = self.ENEMY_ICON_URL.format(boss_id)
+        self.rarity = rarity
+        self.hp_percentage = hp_percentage
+
+    def set_rarity(self, rarity: int) -> None:
+        self.rarity = rarity
+
+    def set_hp_percentage(self, hp_percentage: str) -> None:
+        self.hp_percentage = hp_percentage

--- a/src/karthuria/repository/character_repository.py
+++ b/src/karthuria/repository/character_repository.py
@@ -16,7 +16,7 @@ class CharacterRepository:
 
     def __init__(self, client: KarthuriaClient):
         self.client = client
-        self.characters = self._load_characters()
+        self.characters = self.__load_characters()
 
     def get_characters(self) -> list:
         """
@@ -47,7 +47,7 @@ class CharacterRepository:
             if character.birthday == date:
                 return self.client.get_character(character.id)
 
-    def _load_characters(self) -> list:
+    def __load_characters(self) -> list:
         """
         Calls Karthuria API to load characters basic information
 

--- a/src/karthuria/repository/dress_repository.py
+++ b/src/karthuria/repository/dress_repository.py
@@ -1,0 +1,34 @@
+import logging
+
+from requests import HTTPError
+
+from karthuria.client import KarthuriaClient
+from karthuria.model.character import Dress
+
+LOG_ID = "DressRepository"
+logging.basicConfig(level=logging.INFO)
+
+
+class DressRepository:
+    """
+    Repository with the information of dresses
+    """
+
+    def __init__(self, client: KarthuriaClient):
+        self.client = client
+
+    def get_dress_by_id(self, dress_id: int) -> Dress:
+        """
+        Search for a Dress information by a given ID.
+        If its not found returns None
+
+        :param dress_id: The id to search the dress
+        :return: The Dress instance found for the given id
+        """
+        dress = None
+        try:
+            dress = self.client.get_dress(dress_id)
+            logging.info('[{0}] - Dress wit id [{1}] retrieved successfully'.format(LOG_ID, dress_id))
+        except HTTPError as error:
+            logging.error("[{0}] - Couldn't retrieve Dress with id [{1}]: {2}".format(LOG_ID, dress_id, error))
+        return dress

--- a/src/karthuria/repository/enemy_repository.py
+++ b/src/karthuria/repository/enemy_repository.py
@@ -1,0 +1,34 @@
+import logging
+
+from requests import HTTPError
+
+from karthuria.client import KarthuriaClient
+from karthuria.model.character import Dress
+
+LOG_ID = "EnemyRepository"
+logging.basicConfig(level=logging.INFO)
+
+
+class EnemyRepository:
+    """
+    Repository with the information of enemies
+    """
+
+    def __init__(self, client: KarthuriaClient):
+        self.client = client
+
+    def get_enemy_by_id(self, enemy_id: int) -> Dress:
+        """
+        Search for an Enemy information by a given ID.
+        If its not found returns None
+
+        :param enemy_id: The id to search the Enemy
+        :return: The Enemy instance found for the given id
+        """
+        enemy = None
+        try:
+            enemy = self.client.get_enemy(enemy_id)
+            logging.info('[{0}] - Enemy wit id [{1}] retrieved successfully'.format(LOG_ID, enemy_id))
+        except HTTPError as error:
+            logging.error("[{0}] - Couldn't retrieve Enemy with id [{1}]: {2}".format(LOG_ID, enemy_id, error))
+        return enemy

--- a/src/karthuria/repository/event_repository.py
+++ b/src/karthuria/repository/event_repository.py
@@ -1,0 +1,57 @@
+import logging
+
+from requests import HTTPError
+
+from karthuria.client import KarthuriaClient
+
+LOG_ID = "EventRepository"
+logging.basicConfig(level=logging.INFO)
+
+
+class EventRepository:
+    """
+    Repository with the information of events
+    """
+
+    def __init__(self, client: KarthuriaClient):
+        self.client = client
+        self.events = self.__load_events()
+
+    def get_event_name_by_id(self, event_id: str) -> str:
+        """
+        Search for the name of a event based on the given id.
+
+        :param event_id: Id of the event to search
+        :return: The name of the event
+        """
+        for event in self.events:
+            if str(event.event_id) == str(event_id):
+                return event.name
+
+    def get_current_events(self) -> dict:
+        """
+        Calls Karthuria API to get current ongoing events
+
+        :return: A dict with the different type of ongoing events, like bosses or challenges
+        """
+        current_events = {}
+        try:
+            current_events = self.client.get_current_events()
+            logging.info('[{0}] - Current Events retrieved successfully'.format(LOG_ID))
+        except HTTPError as error:
+            logging.error("[{0}] - Couldn't retrieve current events {1}".format(LOG_ID, error))
+        return current_events
+
+    def __load_events(self) -> list:
+        """
+        Calls Karthuria API to get all events information, mostly its names
+
+        :return: A list with events names and ids
+        """
+        events = []
+        try:
+            events = self.client.get_events()
+            logging.info('[{0}] - Events retrieved successfully'.format(LOG_ID))
+        except HTTPError as error:
+            logging.error("[{0}] - Couldn't retrieve events {1}".format(LOG_ID, error))
+        return events

--- a/src/utils/discord_utils.py
+++ b/src/utils/discord_utils.py
@@ -1,0 +1,11 @@
+import discord
+
+
+def get_discord_color(color: tuple) -> discord.Color:
+    """
+    Given a tuple of rgb colors from each character, return the respective Discord color for it.
+
+    :param color: A tuple with the r, g, b values
+    :return: A discord Color value based on the given values
+    """
+    return discord.Color.from_rgb(color[0], color[1], color[2])

--- a/tests/command/repository/test_server_repository.py
+++ b/tests/command/repository/test_server_repository.py
@@ -15,11 +15,11 @@ class TestLoadServers:
         # Arrange
         mock_is_file.return_value = True
         mock_load_json.return_value = complete_server_info
-        repository = ServerRepository(TEST_JSON)
         expected_name = TEST_SERVER
 
         # Act
-        result = repository.load_servers()
+        repository = ServerRepository(TEST_JSON)
+        result = repository.servers
 
         # Assert
         assert len(result) != 0
@@ -29,10 +29,10 @@ class TestLoadServers:
     def test_when_load_is_not_file(self, mock_is_file):
         # Arrange
         mock_is_file.return_value = False
-        repository = ServerRepository(TEST_JSON)
 
         # Act
-        result = repository.load_servers()
+        repository = ServerRepository(TEST_JSON)
+        result = repository.servers
 
         # Assert
         assert len(result) == 0
@@ -43,10 +43,10 @@ class TestLoadServers:
         # Arrange
         mock_is_file.return_value = True
         mock_load_json.return_value = "No Json"
-        repository = ServerRepository('test.json')
 
         # Act
-        result = repository.load_servers()
+        repository = ServerRepository('test.json')
+        result = repository.servers
 
         # Assert
         assert len(result) == 0
@@ -201,3 +201,44 @@ class TestCreateServer:
 
         # Assert
         assert len(repository.servers) != 0
+
+
+class TestReloadServers:
+
+    @patch('command.configuration.repository.server_repository.is_file')
+    @patch('command.configuration.repository.server_repository.load_json_file')
+    def test_when_new_data_is_added(self, mock_load_json, mock_is_file, complete_server_info, one_channels_server_info):
+        # Arrange
+        mock_is_file.return_value = True
+        mock_load_json.return_value = complete_server_info
+        repository = ServerRepository(TEST_JSON)
+        mock_load_json.return_value = one_channels_server_info
+        expected_name = TEST_SERVER
+
+        # Act
+        repository.reload_servers()
+        result = repository.servers
+
+        # Assert
+        assert result[0].name == expected_name
+        assert result[0].event_channel is None
+
+    @patch('command.configuration.repository.server_repository.is_file')
+    @patch('command.configuration.repository.server_repository.load_json_file')
+    def test_when_data_is_the_same(self, mock_load_json, mock_is_file, complete_server_info):
+        # Arrange
+        mock_is_file.return_value = True
+        mock_load_json.return_value = complete_server_info
+        repository = ServerRepository(TEST_JSON)
+        mock_load_json.return_value = complete_server_info
+        expected_name = TEST_SERVER
+        expected_event_channel_name = 'event-channel'
+
+        # Act
+        repository.reload_servers()
+        result = repository.servers
+
+        # Assert
+        assert result[0].name == expected_name
+        assert result[0].event_channel is not None
+        assert result[0].event_channel.name == expected_event_channel_name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,7 @@ def complete_server_info():
         },
         "event_channel": {
             "channel_id": 1,
-            "name": "birthday-channel"
+            "name": "event-channel"
         }
     }]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def ok_characters_response():
     """
     response = Mock(spec=Response)
     response.ok = True
-    response.json.return_value = get_characters_sample_request()
+    response.json.return_value = get_characters_sample_response()
 
     return response
 
@@ -55,7 +55,7 @@ def ok_character_response():
     """
     response = Mock(spec=Response)
     response.ok = True
-    response.json.return_value = get_character_sample_request()
+    response.json.return_value = get_character_sample_response()
 
     return response
 
@@ -97,9 +97,9 @@ def server_with_channels():
     return server
 
 
-def get_characters_sample_request() -> dict:
+def get_characters_sample_response() -> dict:
     """
-    Sample request of the call to Karthuria API chara.json
+    Sample response of the call to Karthuria API chara.json
 
     :return: A dict with two samples of response of the API, one a valid character and other one invalid
     """
@@ -135,9 +135,9 @@ def get_characters_sample_request() -> dict:
     }
 
 
-def get_character_sample_request():
+def get_character_sample_response():
     """
-    Sample request of the call to Karthuria API chara/id.json
+    Sample response of the call to Karthuria API chara/id.json
 
     :return: A dict with two samples of response of the API with the found character
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from requests import Response, HTTPError
 
 from command.configuration.model.server import Channel, Server
-from karthuria.model.character import Character, Dress
+from karthuria.model.character import Character, Dress, Enemy
 
 
 @pytest.fixture
@@ -21,6 +21,11 @@ def character():
 @pytest.fixture
 def dress():
     return Dress(1, 'Dress Test', 5)
+
+
+@pytest.fixture
+def enemy():
+    return Enemy(1, 'Enemy Test', 1, 1)
 
 
 @pytest.fixture(scope='module')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,62 @@ def ok_character_response():
     return response
 
 
+@pytest.fixture(scope='module')
+def ok_dress_response():
+    """
+    Fixture to return a correct response of the endpoint dress/id.json in Karthuria API
+
+    :return: A Response Mock of the requests library, with its respective ok value and one dress information
+    """
+    response = Mock(spec=Response)
+    response.ok = True
+    response.json.return_value = get_dress_sample_response()
+
+    return response
+
+
+@pytest.fixture(scope='module')
+def ok_enemy_response():
+    """
+    Fixture to return a correct response of the endpoint enemy/id.json in Karthuria API
+
+    :return: A Response Mock of the requests library, with its respective ok value and one enemy information
+    """
+    response = Mock(spec=Response)
+    response.ok = True
+    response.json.return_value = get_enemy_sample_response()
+
+    return response
+
+
+@pytest.fixture(scope='module')
+def ok_events_response():
+    """
+    Fixture to return a correct response of the endpoint event.json in Karthuria API
+
+    :return: A Response Mock of the requests library, with its respective ok value and events information
+    """
+    response = Mock(spec=Response)
+    response.ok = True
+    response.json.return_value = get_events_sample_response()
+
+    return response
+
+
+@pytest.fixture(scope='module')
+def ok_current_events_response():
+    """
+    Fixture to return a correct response of the endpoint current.json in Karthuria API
+
+    :return: A Response Mock of the requests library, with its respective ok value and current events information
+    """
+    response = Mock(spec=Response)
+    response.ok = True
+    response.json.return_value = get_current_events_sample_response()
+
+    return response
+
+
 @pytest.fixture()
 def complete_server_info():
     return [{
@@ -163,6 +219,134 @@ def get_character_sample_response():
             },
             "name_ruby": {
                 "ja": "Claudine Saijo",
+            }
+        }
+    }
+
+
+def get_dress_sample_response():
+    """
+    Sample response of the call to Karthuria API dress/id.json
+
+    :return: A dict with one sample of response of the API with the found dress
+    """
+    return {
+        "basicInfo": {
+            "cardID": "1050009",
+            "rarity": 4,
+            "character": 105,
+            "name": {
+                "ja": "Japanese Tristan",
+                "en": "Tristan"
+            }
+        }
+    }
+
+
+def get_enemy_sample_response():
+    """
+    Sample response of the call to Karthuria API enemy/id.json
+
+    :return: A dict with one sample of response of the API with the found enemy
+    """
+    return {
+        "basicInfo": {
+            "enemyID": "900620402_0",
+            "icon": 9006204,
+            "rarity": 1,
+            "name": {
+                "en": "Resentful Andrew",
+                "ja": "Japanese Andrew"
+            }
+        }
+    }
+
+
+def get_events_sample_response():
+    """
+    Sample response of the call to Karthuria API event.json
+
+    :return: A dict with two samples of response of the API with the found events
+    """
+    return {
+        "1": {
+            "name": {
+                "ja": "Hello to Halloween Japanese",
+                "en": "Hello to Halloween"
+            }
+        },
+        "101": {
+            "name": {
+                "ja": "Troupe Revue (2021/5) Japanese",
+                "en": "Troupe Revue (2021/5)",
+            }
+        },
+    }
+
+
+def get_current_events_sample_response():
+    """
+    Sample response of the call to Karthuria API current.json
+
+    :return: A dict with samples of response of the API with the found current events
+    """
+    return {
+        "titan": {
+            "id": 38,
+            "endAt": 1626033599,
+            "enemy": {
+                "0": {
+                    "id": 900620202,
+                    "hpLeft": 1767977770,
+                    "hpLeftPercent": "58"
+                },
+                "1": {
+                    "id": 900620301,
+                    "hpLeft": 1776909729,
+                    "hpLeftPercent": "59"
+                }
+            },
+            "reward": [
+                7,
+                8
+            ]
+        },
+        "event": {
+            "79": {
+                "id": 79,
+                "info": 0,
+                "beginAt": [
+                    1611640800
+                ],
+                "endAt": [
+                    3999999999
+                ]
+            },
+            "118": {
+                "id": 118,
+                "info": 2021070102,
+                "beginAt": [
+                    1625122800,
+                    1625122800,
+                    1625122800
+                ],
+                "endAt": [
+                    1625813999,
+                    1626073199,
+                    1625813999
+                ]
+            }
+        },
+        "rogue": {
+            "0": {
+                "id": 1050009,
+                "beginAt": 1624863600,
+                "endAt": 1625641199
+            },
+            "1": {
+                "id": 1080009,
+                "beginAt": 1625641200,
+                "endAt": 1626418799
             }
         }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
@@ -5,6 +6,7 @@ from requests import Response, HTTPError
 
 from command.configuration.model.server import Channel, Server
 from karthuria.model.character import Character, Dress, Enemy
+from karthuria.model.event import Event, Challenge, Boss
 
 
 @pytest.fixture
@@ -26,6 +28,28 @@ def dress():
 @pytest.fixture
 def enemy():
     return Enemy(1, 'Enemy Test', 1, 1)
+
+
+@pytest.fixture
+def event():
+    start_date = datetime.now()
+    end_date = datetime.now() + timedelta(days=1)
+    return Event(1, name='Event Test', end_date=end_date.timestamp(), start_date=start_date.timestamp())
+
+
+@pytest.fixture
+def complete_current_events():
+    end_date = datetime.now() + timedelta(days=1)
+    event = Event(1, end_date=end_date.timestamp())
+    challenge = Challenge(2, end_date=end_date.timestamp())
+    boss = Boss(3, end_date=end_date.timestamp())
+
+    current_events = {
+        'events': [event],
+        'challenges': [challenge],
+        'bosses': [boss]
+    }
+    return current_events
 
 
 @pytest.fixture(scope='module')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from requests import Response, HTTPError
 
 from command.configuration.model.server import Channel, Server
-from karthuria.model.character import Character
+from karthuria.model.character import Character, Dress
 
 
 @pytest.fixture
@@ -16,6 +16,11 @@ def character():
         'dislikes': {'en': 'Scary stories (esp. Japanese horror films)'},
     }
     return Character(104, 'Claudine Saijo', 1, 8, 1, detailed_info)
+
+
+@pytest.fixture
+def dress():
+    return Dress(1, 'Dress Test', 5)
 
 
 @pytest.fixture(scope='module')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,23 @@ def ok_current_events_response():
     return response
 
 
+@pytest.fixture(scope='module')
+def only_challenge_current_events_response():
+    """
+    Fixture to return a correct response of the endpoint current.json in Karthuria API when only challenge exist
+
+    :return: A Response Mock of the requests library, with its respective ok value and current events information
+    """
+    complete_response = get_current_events_sample_response()
+    response = Mock(spec=Response)
+    response.ok = True
+    response.json.return_value = {
+        'rogue': complete_response['rogue']
+    }
+
+    return response
+
+
 @pytest.fixture()
 def complete_server_info():
     return [{

--- a/tests/karthuria/repository/test_dress_repository.py
+++ b/tests/karthuria/repository/test_dress_repository.py
@@ -1,0 +1,34 @@
+from unittest.mock import Mock
+
+from requests import HTTPError
+
+from karthuria.client import KarthuriaClient
+from karthuria.repository.dress_repository import DressRepository
+
+
+class TestGetDressById:
+
+    def test_when_dress_is_found(self, dress):
+        # Arrange
+        mock_client = Mock(spec=KarthuriaClient)
+        mock_client.get_dress.return_value = dress
+        repository = DressRepository(mock_client)
+        expected_name = 'Dress Test'
+
+        # Act
+        response = repository.get_dress_by_id(1)
+
+        # Assert
+        assert response.name == expected_name
+
+    def test_when_dress_is_not_found(self):
+        # Arrange
+        mock_client = Mock(spec=KarthuriaClient)
+        mock_client.get_dress.side_effect = HTTPError('Ups')
+        repository = DressRepository(mock_client)
+
+        # Act
+        response = repository.get_dress_by_id(2)
+
+        # Assert
+        assert response is None

--- a/tests/karthuria/repository/test_enemy_repository.py
+++ b/tests/karthuria/repository/test_enemy_repository.py
@@ -1,0 +1,34 @@
+from unittest.mock import Mock
+
+from requests import HTTPError
+
+from karthuria.client import KarthuriaClient
+from karthuria.repository.enemy_repository import EnemyRepository
+
+
+class TestGetEnemyById:
+
+    def test_when_enemy_is_found(self, enemy):
+        # Arrange
+        mock_client = Mock(spec=KarthuriaClient)
+        mock_client.get_enemy.return_value = enemy
+        repository = EnemyRepository(mock_client)
+        expected_name = 'Enemy Test'
+
+        # Act
+        response = repository.get_enemy_by_id(1)
+
+        # Assert
+        assert response.name == expected_name
+
+    def test_when_enemy_is_not_found(self):
+        # Arrange
+        mock_client = Mock(spec=KarthuriaClient)
+        mock_client.get_enemy.side_effect = HTTPError('Ups')
+        repository = EnemyRepository(mock_client)
+
+        # Act
+        response = repository.get_enemy_by_id(2)
+
+        # Assert
+        assert response is None

--- a/tests/karthuria/repository/test_event_repository.py
+++ b/tests/karthuria/repository/test_event_repository.py
@@ -1,0 +1,96 @@
+from unittest.mock import Mock
+
+from requests import HTTPError
+
+from karthuria.client import KarthuriaClient
+from karthuria.repository.event_repository import EventRepository
+
+
+class TestLoadEvents:
+
+    def test_when_events_load_successful(self, event):
+        # Arrange
+        mock_client = Mock(spec=KarthuriaClient)
+        mock_client.get_events.return_value = [event]
+        repository = EventRepository(mock_client)
+
+        # Act
+        response = repository.events
+
+        # Assert
+        assert len(response) == 1
+        assert response[0].event_id == 1
+
+    def test_when_events_load_unsuccessful(self):
+        # Arrange
+        mock_client = Mock(spec=KarthuriaClient)
+        mock_client.get_events.side_effect = HTTPError('Ups')
+        repository = EventRepository(mock_client)
+
+        # Act
+        response = repository.events
+
+        # Assert
+        assert len(response) == 0
+
+
+class TestGetCurrentEvents:
+
+    def test_when_all_events_are_present(self, complete_current_events):
+        # Arrange
+        mock_client = Mock(spec=KarthuriaClient)
+        mock_client.get_current_events.return_value = complete_current_events
+        repository = EventRepository(mock_client)
+
+        # Act
+        response = repository.get_current_events()
+
+        # Assert
+        assert response is not None
+        assert len(response) != 0
+        assert 'events' in response
+        assert response['events'][0].event_id == 1
+        assert 'challenges' in response
+        assert response['challenges'][0].event_id == 2
+        assert 'bosses' in response
+        assert response['bosses'][0].event_id == 3
+
+    def test_when_current_events_are_unsuccessful(self):
+        # Arrange
+        mock_client = Mock(spec=KarthuriaClient)
+        mock_client.get_current_events.side_effect = HTTPError('Ups')
+        repository = EventRepository(mock_client)
+
+        # Act
+        response = repository.get_current_events()
+
+        # Assert
+        assert len(response) == 0
+
+
+class TestGetEventNameById:
+
+    def test_when_event_is_found(self, event):
+        # Arrange
+        mock_client = Mock(spec=KarthuriaClient)
+        mock_client.get_events.return_value = [event]
+        repository = EventRepository(mock_client)
+        expected_name = 'Event Test'
+
+        # Act
+        response = repository.get_event_name_by_id(1)
+
+        # Assert
+        assert response == expected_name
+
+    def test_when_event_is_not_found(self, event):
+        # Arrange
+        mock_client = Mock(spec=KarthuriaClient)
+        mock_client.get_events.return_value = [event]
+        repository = EventRepository(mock_client)
+
+        # Act
+        response = repository.get_event_name_by_id(2)
+
+        # Assert
+        assert response is None

--- a/tests/karthuria/test_client.py
+++ b/tests/karthuria/test_client.py
@@ -4,8 +4,8 @@ import pytest
 import requests
 from requests import HTTPError
 
-from karthuria.model.color import Color
 from karthuria.client import KarthuriaClient
+from karthuria.model.color import Color
 from karthuria.model.school import School
 
 client = KarthuriaClient('test_url')
@@ -14,21 +14,25 @@ client = KarthuriaClient('test_url')
 class TestGetCharacters:
 
     def test_when_response_is_successful(self, ok_characters_response):
-        # Arrange and Act
+        # Arrange
+        expected_name = 'Claudine Saijo'
+
+        # Act
         with patch.object(requests, 'get', return_value=ok_characters_response) as requests_mock:
             response = client.get_characters()
 
         # Assert
         requests_mock.assert_called()
         assert len(response) == 1
-        assert response[0].name == 'Claudine Saijo'
+        assert response[0].name == expected_name
         assert response[0].school.description == School.SEISHO.description
         assert str(response[0].school) == str(School.SEISHO.value)
 
     def test_when_response_is_no_successful(self, bad_response):
-        # Arrange and Act
+        # Arrange
         expected_error_message = 'Ups'
 
+        # Act
         with patch.object(requests, 'get', return_value=bad_response) as requests_mock:
             with pytest.raises(HTTPError) as exception:
                 client.get_characters()
@@ -41,25 +45,30 @@ class TestGetCharacters:
 class TestGetCharacter:
 
     def test_when_response_is_successful(self, ok_character_response):
-        # Arrange and Act
+        # Arrange
+        expected_name = 'Claudine Saijo'
+        expected_seiyuu = 'Aina Aiba'
+
+        # Act
         with patch.object(requests, 'get', return_value=ok_character_response) as requests_mock:
             response = client.get_character(1)
 
         # Assert
         requests_mock.assert_called()
         assert response is not None
-        assert response.name == 'Claudine Saijo'
-        assert response.seiyuu == 'Aina Aiba'
+        assert response.name == expected_name
+        assert response.seiyuu == expected_seiyuu
         assert response.color.rgb == Color.CLAUDINE.rgb
         assert str(response.color) == Color.CLAUDINE.value
 
     def test_when_response_is_no_successful(self, bad_response):
-        # Arrange and Act
+        # Arrange
         expected_error_message = 'Ups'
 
+        # Act
         with patch.object(requests, 'get', return_value=bad_response) as requests_mock:
             with pytest.raises(HTTPError) as exception:
-                client.get_characters()
+                client.get_character(1)
 
         # Assert
         requests_mock.assert_called()

--- a/tests/karthuria/test_client.py
+++ b/tests/karthuria/test_client.py
@@ -73,3 +73,117 @@ class TestGetCharacter:
         # Assert
         requests_mock.assert_called()
         assert str(exception.value) == expected_error_message
+
+
+class TestGetDress:
+
+    def test_when_response_is_successful(self, ok_dress_response):
+        # Arrange
+        expected_name = 'Tristan'
+
+        # Act
+        with patch.object(requests, 'get', return_value=ok_dress_response) as requests_mock:
+            response = client.get_dress(1)
+
+        # Assert
+        requests_mock.assert_called()
+        assert response is not None
+        assert response.name == expected_name
+
+    def test_when_response_is_no_successful(self, bad_response):
+        # Arrange
+        expected_error_message = 'Ups'
+
+        # Act
+        with patch.object(requests, 'get', return_value=bad_response) as requests_mock:
+            with pytest.raises(HTTPError) as exception:
+                client.get_dress(1)
+
+        # Assert
+        requests_mock.assert_called()
+        assert str(exception.value) == expected_error_message
+
+
+class TestGetEnemy:
+
+    def test_when_response_is_successful(self, ok_enemy_response):
+        # Arrange
+        expected_name = 'Resentful Andrew'
+        expected_rarity = 1
+
+        # Act
+        with patch.object(requests, 'get', return_value=ok_enemy_response) as requests_mock:
+            response = client.get_enemy(1)
+
+        # Assert
+        requests_mock.assert_called()
+        assert response is not None
+        assert response.name == expected_name
+        assert response.rarity == expected_rarity
+
+    def test_when_response_is_no_successful(self, bad_response):
+        # Arrange
+        expected_error_message = 'Ups'
+
+        # Act
+        with patch.object(requests, 'get', return_value=bad_response) as requests_mock:
+            with pytest.raises(HTTPError) as exception:
+                client.get_enemy(1)
+
+        # Assert
+        requests_mock.assert_called()
+        assert str(exception.value) == expected_error_message
+
+
+class TestGetEvents:
+
+    def test_when_response_is_successful(self, ok_events_response):
+        # Arrange
+        expected_name = 'Hello to Halloween'
+        expected_event_id = '101'
+
+        # Act
+        with patch.object(requests, 'get', return_value=ok_events_response) as requests_mock:
+            response = client.get_events()
+
+        # Assert
+        requests_mock.assert_called()
+        assert response is not None
+        assert len(response) == 2
+        assert response[0].name == expected_name
+        assert response[1].event_id == expected_event_id
+
+    def test_when_response_is_no_successful(self, bad_response):
+        # Arrange
+        expected_error_message = 'Ups'
+
+        # Act
+        with patch.object(requests, 'get', return_value=bad_response) as requests_mock:
+            with pytest.raises(HTTPError) as exception:
+                client.get_events()
+
+        # Assert
+        requests_mock.assert_called()
+        assert str(exception.value) == expected_error_message
+
+
+class TestGetCurrentEvents:
+    def test_when_response_is_successful(self, ok_current_events_response):
+        # Arrange
+        expected_event_id = 118
+        expected_challenge_id = 1080009
+        expected_boss_id = 900620202
+
+        # Act
+        with patch.object(requests, 'get', return_value=ok_current_events_response) as requests_mock:
+            response = client.get_current_events()
+
+        # Assert
+        requests_mock.assert_called()
+        assert response is not None
+        assert len(response['events']) == 1
+        assert response['events'][0].event_id == expected_event_id
+        assert len(response['challenges']) == 2
+        assert response['challenges'][1].event_id == expected_challenge_id
+        assert len(response['bosses']) == 2
+        assert response['bosses'][0].event_id == expected_boss_id

--- a/tests/karthuria/test_client.py
+++ b/tests/karthuria/test_client.py
@@ -187,3 +187,32 @@ class TestGetCurrentEvents:
         assert response['challenges'][1].event_id == expected_challenge_id
         assert len(response['bosses']) == 2
         assert response['bosses'][0].event_id == expected_boss_id
+
+    def test_when_only_challenge_is_present(self, only_challenge_current_events_response):
+        # Arrange
+        expected_challenge_id = 1080009
+
+        # Act
+        with patch.object(requests, 'get', return_value=only_challenge_current_events_response) as requests_mock:
+            response = client.get_current_events()
+
+        # Assert
+        requests_mock.assert_called()
+        assert response is not None
+        assert len(response['challenges']) == 2
+        assert response['challenges'][1].event_id == expected_challenge_id
+        assert 'events' not in response
+        assert 'bosses' not in response
+
+    def test_when_response_is_no_successful(self, bad_response):
+        # Arrange
+        expected_error_message = 'Ups'
+
+        # Act
+        with patch.object(requests, 'get', return_value=bad_response) as requests_mock:
+            with pytest.raises(HTTPError) as exception:
+                client.get_current_events()
+
+        # Assert
+        requests_mock.assert_called()
+        assert str(exception.value) == expected_error_message

--- a/tests/utils/test_discord_utils.py
+++ b/tests/utils/test_discord_utils.py
@@ -1,0 +1,28 @@
+import pytest
+
+from utils.discord_utils import get_discord_color
+
+
+class TestGetDiscordColor:
+
+    def test_when_color_is_found_int_tuple(self):
+        # Arrange
+        color_tuple = (0, 0, 0)
+
+        # Act
+        result = get_discord_color(color_tuple)
+
+        # Assert
+        assert result.value == 0
+
+    def test_when_color_is_str_tuple(self):
+        # Arrange
+        color_tuple = ('hi', 'test', 'lol')
+        expected_error_message = 'unsupported operand type(s)'
+
+        # Act
+        with pytest.raises(TypeError) as exception:
+            get_discord_color(color_tuple)
+
+        # Assert
+        assert expected_error_message in str(exception.value)


### PR DESCRIPTION
## Event Command ##
### New ###
- Added `current_events` command to show a list of current events in all Re-live servers.
```
!current_events
```
![image](https://user-images.githubusercontent.com/7529833/124554495-a635b700-ddfb-11eb-98ca-5ed86f737891.png)
- Added event command to `setting.json` to be loaded

## Birthday Command ##
### Changes ###
- Changed some functions from protected to public, like `special_message_birthday`
- Removed `_get_discord_color` and moved it to a new package called `discord_utils `to be use in different commands.
- Changed call to `load_servers` for `reload_servers`

## Project Details ##
### New ###
- Added new utils package called `discord_utils`
- Added new `reload_servers` function to `ServerRepository`
- Added Enemy, Event and Dress Repository
- Added new endpoint to `KarthuriaClient`

### Changes ###
- Changed `load_servers` from public to private in `ServerRepository`
- Refactored some fixture names and general tests structure.