### PR TITLE
Hotifx - Fix characters birthday format

### DIFF
--- a/src/karthuria/model/character.py
+++ b/src/karthuria/model/character.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from karthuria.model.color import Color
 from karthuria.model.school import School
 
@@ -13,7 +15,7 @@ class Character:
     def __init__(self, chara_id, name, birth_day, birth_month, school_id, detailed_info=None):
         self.id = chara_id
         self.name = name
-        self.birthday = '{0}/{1}'.format(birth_day, birth_month)
+        self.birthday = datetime(1, birth_month, birth_day).strftime('%d/%m')
         self.school = School(school_id)
         self.portrait = PORTRAIT_URL.format(self.id)
         self.color = Color(name)

--- a/tests/karthuria/repository/test_character_repository.py
+++ b/tests/karthuria/repository/test_character_repository.py
@@ -73,7 +73,7 @@ class TestGetCharacterBirthday:
         expected_name = 'Claudine Saijo'
 
         # Act
-        response = repository.get_character_birthday('1/8')
+        response = repository.get_character_birthday('01/08')
 
         # Assert
         assert response.name == expected_name
@@ -86,7 +86,7 @@ class TestGetCharacterBirthday:
         repository = CharacterRepository(mock_client)
 
         # Act
-        response = repository.get_character_birthday('1/9')
+        response = repository.get_character_birthday('01/09')
 
         # Assert
         assert response is None


### PR DESCRIPTION
## Birthday Command ##
### Fixes ###
- Fixed a bug where some birthdays with only one digit in their dates were formatted like 01 or 08 instead of just 1 or 8 and that makes sense. So instead of saving the date as plain string, thins time is converted to a datetime and then transform to a string with the utilities.