### PR TITLE
Feature - Add Remove Announcements Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ This bot works either with `!` or `$` prefixes.
 !events_announcements general admins
 ```
 
+- **remove_announcements**: Allow server admins to remove an event or birthday announcements configurations to avoid
+  receiving notifications from Kuro Bot on the pre-configured channels. <br>
+  Please use `event`, `birthday` or both to specify the announcement to remove.
+  
+```
+!remove_announcements event
+!remove_announcements birthday
+!remove_announcements event birthday
+```
+
 ### Tasks ###
 
 This bot has the following automatic tasks that will be executed in any server.

--- a/src/command/configuration/configuration.py
+++ b/src/command/configuration/configuration.py
@@ -45,6 +45,36 @@ class ConfigurationCommand(commands.Cog):
         """
         await self.__configure_announcement(ctx, channel_name, announcement_rol, ChannelType.EVENT)
 
+    @commands.command(pass_context=True)
+    async def remove_announcements(self, ctx: Context, *announcement_types):
+        """
+        Remove configuration for a given type of announcement, either event or birthday.
+        :param ctx: Discord context
+        :param announcement_types: The type of announcement to remove its configuration
+        :return: None
+        """
+        if not ctx.message.author.guild_permissions.administrator:
+            await ctx.send('Désolé, tout utilisateur. Only server admins can use this command.')
+            return
+
+        if len(announcement_types) == 0:
+            await ctx.send("Hmm...Please specify announcement configurations you want to remove")
+            return
+
+        changed_something = False
+        for channel_type in announcement_types:
+            if channel_type.lower() == 'event':
+                changed_something = True
+                self.server_repository.remove_server_channel(ctx.guild.id, ChannelType.EVENT)
+                await ctx.send('Comme tu as insisté...I removed events configurations.')
+            if channel_type.lower() == 'birthday':
+                changed_something = True
+                self.server_repository.remove_server_channel(ctx.guild.id, ChannelType.BIRTHDAY)
+                await ctx.send('Comme tu as insisté...I removed birthday configurations.')
+
+        if not changed_something:
+            await ctx.send("I couldn't find any configuration to remove, dommage :wink:")
+
     async def __configure_announcement(self, ctx: Context, channel_name: str, announcement_rol: str,
                                        channel_type: ChannelType):
         """

--- a/src/command/configuration/configuration.py
+++ b/src/command/configuration/configuration.py
@@ -1,11 +1,10 @@
-from discord import Role
-from discord.abc import GuildChannel
 from discord.ext import commands
 from discord.ext.commands import Context
 
 from command.configuration.model.channel_type import ChannelType
 from command.configuration.repository.server_repository import ServerRepository
 from command.initializer import Initializer
+from utils.discord_utils import get_rol, get_channel_by_name
 
 LOG_ID = "ConfigurationCommand"
 
@@ -31,29 +30,7 @@ class ConfigurationCommand(commands.Cog):
             If is not set then everyone will be by default.
         :return: None
         """
-        if not ctx.message.author.guild_permissions.administrator:
-            await ctx.send('Désolé, tout utilisateur. Only server admins can use this command.')
-            return
-
-        if channel_name is None:
-            await ctx.send('Hmm...Please specify the channel name.')
-            return
-
-        channel = get_channel_id(ctx, channel_name)
-        rol = ctx.guild.default_role if announcement_rol is None else get_rol(ctx, announcement_rol)
-
-        if rol is None:
-            await ctx.send("Je suis desolé - I wasn't able to find role [{0}]".format(announcement_rol))
-            return
-
-        if channel is not None:
-            log_rol = rol.name if rol.name != '@everyone' else rol.name[1::]
-            self.server_repository.create_server(ctx.guild.id, ctx.guild.name, channel.id, channel.name,
-                                                 ChannelType.BIRTHDAY, rol.id)
-            await ctx.send('Fait! - Birthday channel [{0}] was set with role [{1}]'.format(channel_name, log_rol))
-            return
-
-        await ctx.send("Je suis desolé - I wasn't able to find channel [{0}]".format(channel_name))
+        await self.__configure_announcement(ctx, channel_name, announcement_rol, ChannelType.BIRTHDAY)
 
     @commands.command(pass_context=True)
     async def events_announcements(self, ctx: Context, channel_name: str = None, announcement_rol: str = None) -> None:
@@ -66,6 +43,20 @@ class ConfigurationCommand(commands.Cog):
             If is not set then everyone will be by default.
         :return: None
         """
+        await self.__configure_announcement(ctx, channel_name, announcement_rol, ChannelType.EVENT)
+
+    async def __configure_announcement(self, ctx: Context, channel_name: str, announcement_rol: str,
+                                       channel_type: ChannelType):
+        """
+        Configure an Event or Birthday channel announcement with its respective rol if is specified.
+
+        :param ctx: Discord context
+        :param channel_name: Name of the channel where notification will be send.
+        :param announcement_rol: The rol that will be use to notify in the birthday or event channel.
+            If is not set then everyone will be by default.
+        :param channel_type: The type of channel that is being configured, either EVENT or BIRTHDAY
+        :return: None
+        """
         if not ctx.message.author.guild_permissions.administrator:
             await ctx.send('Désolé, tout utilisateur. Only server admins can use this command.')
             return
@@ -74,7 +65,7 @@ class ConfigurationCommand(commands.Cog):
             await ctx.send('Hmm...Please specify the channel name.')
             return
 
-        channel = get_channel_id(ctx, channel_name)
+        channel = get_channel_by_name(ctx, channel_name)
         rol = ctx.guild.default_role if announcement_rol is None else get_rol(ctx, announcement_rol)
 
         if rol is None:
@@ -83,40 +74,14 @@ class ConfigurationCommand(commands.Cog):
 
         if channel is not None:
             log_rol = rol.name if rol.name != '@everyone' else rol.name[1::]
-            self.server_repository.create_server(ctx.guild.id, ctx.guild.name, channel.id, channel.name,
-                                                 ChannelType.EVENT, rol.id)
-            await ctx.send('Fait! - Event channel [{0}] was set with role [{1}]'.format(channel_name, log_rol))
+            self.server_repository.create_server(ctx.guild.id, ctx.guild.name, channel.id, channel.name, channel_type,
+                                                 rol.id)
+            channel_type_message = 'Event' if channel_type == ChannelType.EVENT else 'Birthday'
+            await ctx.send('Fait! - {0} channel [{1}] was set with role [{2}]'.format(channel_type_message,
+                                                                                      channel_name, log_rol))
             return
 
-        await ctx.send("Je suis desolé - I wasn't able to find  [{0}]".format(channel_name))
-
-
-def get_rol(ctx: Context, role_name: str) -> Role:
-    """
-    Look for the respective rol in a Guild based on the specified rol name
-
-    :param ctx: Discord Context of execution
-    :param role_name: the rol to find
-    :return: Instance of Role for the specified name
-    """
-    roles = ctx.guild.roles
-    for rol in roles:
-        if rol.name == role_name:
-            return rol
-
-
-def get_channel_id(ctx: Context, channel_name: str) -> GuildChannel:
-    """
-    Look for the respective channel in a Guild based on the specified channel name
-
-    :param ctx: Discord Context of execution
-    :param channel_name: the channel to find
-    :return: Instance of GuildChannel for the specified name
-    """
-    channels = ctx.guild.channels
-    for channel in channels:
-        if channel.name == channel_name:
-            return channel
+        await ctx.send("Je suis desolé - I wasn't able to find channel [{0}]".format(channel_name))
 
 
 def setup(my_bot: commands.Bot) -> None:

--- a/src/command/configuration/model/server.py
+++ b/src/command/configuration/model/server.py
@@ -28,6 +28,13 @@ class Server:
         """
         self.birthday_channel = birthday_channel
 
+    def remove_birthday_channel(self) -> None:
+        """
+        Remove a Channel from the birthday configuration.
+        :return: None
+        """
+        self.birthday_channel = None
+
     def add_event_channel(self, event_channel: Channel) -> None:
         """
         Add a Channel to event configuration if it wasn't specified before
@@ -35,3 +42,10 @@ class Server:
         :return: None
         """
         self.event_channel = event_channel
+
+    def remove_event_channel(self) -> None:
+        """
+        Remove a Channel from the event configuration.
+        :return: None
+        """
+        self.event_channel = None

--- a/src/command/configuration/repository/server_repository.py
+++ b/src/command/configuration/repository/server_repository.py
@@ -49,6 +49,20 @@ class ServerRepository:
         add_channel(channel)
         self.__save_server(server)
 
+    def remove_server_channel(self, server_id: int, channel_type: ChannelType) -> None:
+        """
+        Remove an specified channel from a channel.
+        :param server_id: The id that identifies the server
+        :param channel_type: Channel type to be remove in the server
+        :return: None
+        """
+        server = self.find_server_by_id(server_id)
+
+        if server is not None:
+            remove_channel = getattr(server, 'remove_{0}'.format(channel_type.value))
+            remove_channel()
+            self.__save_server(server)
+
     def __save_server(self, new_server: Server) -> None:
         """
         Saves into a pre configured json file the information of a server.

--- a/src/utils/discord_utils.py
+++ b/src/utils/discord_utils.py
@@ -1,4 +1,7 @@
 import discord
+from discord import Role
+from discord.abc import GuildChannel
+from discord.ext.commands import Context
 
 
 def get_discord_color(color: tuple) -> discord.Color:
@@ -9,3 +12,31 @@ def get_discord_color(color: tuple) -> discord.Color:
     :return: A discord Color value based on the given values
     """
     return discord.Color.from_rgb(color[0], color[1], color[2])
+
+
+def get_rol(ctx: Context, role_name: str) -> Role:
+    """
+    Look for the respective rol in a Guild based on the specified rol name
+
+    :param ctx: Discord Context of execution
+    :param role_name: the rol to find
+    :return: Instance of Role for the specified name
+    """
+    roles = ctx.guild.roles
+    for rol in roles:
+        if rol.name == role_name:
+            return rol
+
+
+def get_channel_by_name(ctx: Context, channel_name: str) -> GuildChannel:
+    """
+    Look for the respective channel in a Guild based on the specified channel name
+
+    :param ctx: Discord Context of execution
+    :param channel_name: the channel to find
+    :return: Instance of GuildChannel for the specified name
+    """
+    channels = ctx.guild.channels
+    for channel in channels:
+        if channel.name == channel_name:
+            return channel

--- a/tests/command/repository/test_server_repository.py
+++ b/tests/command/repository/test_server_repository.py
@@ -253,3 +253,65 @@ class TestReloadServers:
         assert result[0].name == expected_name
         assert result[0].event_channel is not None
         assert result[0].event_channel.name == expected_event_channel_name
+
+
+class TestRemoveServerChannel:
+
+    @patch('command.configuration.repository.server_repository.is_file')
+    @patch('command.configuration.repository.server_repository.load_json_file')
+    @patch('command.configuration.repository.server_repository.write_json_file')
+    def test_when_birthday_channel_was_removed(self, mock_write_json, mock_load_json, mock_is_file,
+                                               complete_server_info):
+        # Arrange
+        mock_is_file.return_value = True
+        mock_load_json.return_value = complete_server_info
+        mock_write_json.return_value = None
+        repository = ServerRepository(TEST_JSON)
+        expected_server_id = 1
+
+        # Act
+        repository.remove_server_channel(expected_server_id, ChannelType.BIRTHDAY)
+
+        # Assert
+        assert len(repository.servers) != 0
+        assert repository.servers[0].birthday_channel is None
+        assert repository.servers[0].event_channel is not None
+
+    @patch('command.configuration.repository.server_repository.is_file')
+    @patch('command.configuration.repository.server_repository.load_json_file')
+    @patch('command.configuration.repository.server_repository.write_json_file')
+    def test_when_events_channel_was_removed(self, mock_write_json, mock_load_json, mock_is_file, complete_server_info):
+        # Arrange
+        mock_is_file.return_value = True
+        mock_load_json.return_value = complete_server_info
+        mock_write_json.return_value = None
+        repository = ServerRepository(TEST_JSON)
+        expected_server_id = 1
+
+        # Act
+        repository.remove_server_channel(expected_server_id, ChannelType.EVENT)
+
+        # Assert
+        assert len(repository.servers) != 0
+        assert repository.servers[0].birthday_channel is not None
+        assert repository.servers[0].event_channel is None
+
+    @patch('command.configuration.repository.server_repository.is_file')
+    @patch('command.configuration.repository.server_repository.load_json_file')
+    @patch('command.configuration.repository.server_repository.write_json_file')
+    def test_when_some_channel_was_removed_but_server_wasnt_configured(self, mock_write_json, mock_load_json,
+                                                                       mock_is_file, complete_server_info):
+        # Arrange
+        mock_is_file.return_value = True
+        mock_load_json.return_value = complete_server_info
+        mock_write_json.return_value = None
+        repository = ServerRepository(TEST_JSON)
+        expected_server_id = 2
+
+        # Act
+        repository.remove_server_channel(expected_server_id, ChannelType.EVENT)
+
+        # Assert
+        assert len(repository.servers) != 0
+        assert repository.servers[0].birthday_channel is not None
+        assert repository.servers[0].event_channel is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
+from discord import Role, TextChannel, Guild
 from requests import Response, HTTPError
 
 from command.configuration.model.server import Channel, Server
@@ -205,6 +206,22 @@ def server_with_channels():
     event_channel = Channel(2, 'event_channel', 2)
     server = Server(1, 'Test Channel', birthday_channel, event_channel)
     return server
+
+
+@pytest.fixture()
+def discord_role():
+    data = {'id': 1, 'name': 'Test'}
+    test_role = Role(guild='tests guild', state=True, data=data)
+    return test_role
+
+
+@pytest.fixture()
+def discord_channel():
+    data = {'id': 1, 'name': 'Test', 'type': 'Text', 'position': 1}
+    mock_guild = Mock(spec=Guild)
+    mock_guild.id = 1
+    test_channel = TextChannel(guild=mock_guild, state=True, data=data)
+    return test_channel
 
 
 def get_characters_sample_response() -> dict:

--- a/tests/utils/test_discord_utils.py
+++ b/tests/utils/test_discord_utils.py
@@ -1,6 +1,8 @@
+from unittest.mock import patch
+
 import pytest
 
-from utils.discord_utils import get_discord_color
+from utils.discord_utils import get_discord_color, get_rol, get_channel_by_name
 
 
 class TestGetDiscordColor:
@@ -26,3 +28,59 @@ class TestGetDiscordColor:
 
         # Assert
         assert expected_error_message in str(exception.value)
+
+
+class TestGetRol:
+
+    def test_when_rol_exist(self, discord_role):
+        # Arrange
+        test_rol = 'Test'
+
+        # Act
+        with patch('discord.ext.commands.Context') as mock_context:
+            mock_context.guild.roles = [discord_role]
+            result = get_rol(mock_context, test_rol)
+
+        # Assert
+        assert result is not None
+        assert result.name == test_rol
+
+    def test_when_rol_dont_exist(self, discord_role):
+        # Arrange
+        test_rol = 'Test 2'
+
+        # Act
+        with patch('discord.ext.commands.Context') as mock_context:
+            mock_context.guild.roles = [discord_role]
+            result = get_rol(mock_context, test_rol)
+
+        # Assert
+        assert result is None
+
+
+class TestGetChannelByName:
+
+    def test_when_channel_exist(self, discord_channel):
+        # Arrange
+        test_channel = 'Test'
+
+        # Act
+        with patch('discord.ext.commands.Context') as mock_context:
+            mock_context.guild.channels = [discord_channel]
+            result = get_channel_by_name(mock_context, test_channel)
+
+        # Assert
+        assert result is not None
+        assert result.name == test_channel
+
+    def test_when_channel_dont_exist(self, discord_channel):
+        # Arrange
+        test_channel = 'Test 2'
+
+        # Act
+        with patch('discord.ext.commands.Context') as mock_context:
+            mock_context.guild.channels = [discord_channel]
+            result = get_channel_by_name(mock_context, test_channel)
+
+        # Assert
+        assert result is None


### PR DESCRIPTION
## Configuration Command ##
### New ###
- Added new command `remove_announcements` to remove previous configured channels and roles for event and birthday announcements. This with the intention to remove notifications without removing `Kuro-Bot`.
```
!remove_announcements event
!remove_announcements birthday
!remove_announcements event birthday
```
- Added new `Server` function to remove `Channel` configuration with `remove_event_channel()` and `remove_birthday_channel()`
- Added new function in `Server Repository` to remove channel configuration in an specific server.
### Changes ###
- Refactored logic to configure event and birthday announcements. Instead of duplicated code now they use the same method.

## Project Details ##
### Changes ###
- Moved function `get_role()` from `Configuration` file to `discord_utils`
- Moved function `get_channel_id` to  `discord_utils` and renamed to `get_channel_by_name` since the name is more fitting to the function job.