### PR TITLE
Feature: Handle CDN url as setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kuro Bot #
 
-[![kuroversion](https://img.shields.io/badge/version-1.3.0-fe9952)]()
+[![kuroversion](https://img.shields.io/badge/version-1.3.1-fe9952)]()
 [![python](https://img.shields.io/badge/python-3.7-376fa0)](https://www.python.org/)
 [![karthuria](https://img.shields.io/badge/Karthuria-API-fb5457)](https://karth.top/home)
 [![status](https://img.shields.io/badge/status-online-green)]()

--- a/settings.json
+++ b/settings.json
@@ -8,5 +8,6 @@
     "command.love.love"
   ],
   "karthuria_api_url": "https://karth.top/api",
+  "karthuria_cdn_url": "https://cdn.karth.top/assets",
   "servers_path": "servers.json"
 }

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ packages = [
 
 setuptools.setup(
     name='kuro-bot',
-    version='1.3.0',
+    version='1.3.1',
     packages=packages,
     author='Juliana Diaz',
     description='Basic informational Bot of Shoujo Kageki Revue Starlight franchise',

--- a/src/command/birthday/birthday.py
+++ b/src/command/birthday/birthday.py
@@ -14,20 +14,19 @@ from utils.discord_utils import get_discord_color
 
 LOG_ID = "BirthdayCommand"
 
-SCHOOL_ICON_URL = 'https://cdn.karth.top/api/assets/jp/res/ui/images/chat/icon_school_{0}.png'
-
 
 class BirthdayCommand(commands.Cog):
     """
     All Kuro bot discord commands that are related to birthdays. Either to get birthday information or to notify them
     """
 
-    def __init__(self, character_repository: CharacterRepository, server_repository: ServerRepository,
+    def __init__(self, character_repository: CharacterRepository, server_repository: ServerRepository, cdn_url: str,
                  my_bot=commands.Bot):
         self.bot = my_bot
         self.character_repository = character_repository
         self.server_repository = server_repository
         self.birthday_reminder.start()
+        self.school_icon_url = '{0}/{1}'.format(cdn_url, 'res/ui/images/chat/icon_school_{0}.png')
 
     @commands.command(pass_context=True)
     async def birthday(self, ctx: Context, name: str = None) -> None:
@@ -80,7 +79,7 @@ class BirthdayCommand(commands.Cog):
                     if server.birthday_channel is not None:
                         channel = self.bot.get_channel(server.birthday_channel.channel_id)
                         rol = guild.get_role(server.birthday_channel.announcement_rol)
-                        embed = build_birthday_reminder_embed(birthday_girl)
+                        embed = build_birthday_reminder_embed(birthday_girl, self.school_icon_url)
                         await channel.send(rol.mention, embed=embed)
                     else:
                         logging.warning('[{0}] - Missing configuration for birthday channel '
@@ -98,11 +97,12 @@ class BirthdayCommand(commands.Cog):
         logging.debug('[{0}] - Birthday reminders ready!'.format(LOG_ID))
 
 
-def build_birthday_reminder_embed(birthday_girl: Character) -> discord.Embed:
+def build_birthday_reminder_embed(birthday_girl: Character, school_icon_url: str) -> discord.Embed:
     """
     Build the birthday reminder message with the respective format and given information.
 
     :param birthday_girl: The stage girl that is celebrating its birthday
+    :param school_icon_url: The url of the school shield
     :return: Discord Embed with the defined format to use
     """
 
@@ -113,7 +113,7 @@ def build_birthday_reminder_embed(birthday_girl: Character) -> discord.Embed:
 
     embed = discord.Embed(title=title, description=message, color=get_discord_color(rgb))
     embed.set_thumbnail(url=birthday_girl.portrait)
-    embed.set_image(url=SCHOOL_ICON_URL.format(birthday_girl.school))
+    embed.set_image(url=school_icon_url.format(birthday_girl.school))
     embed.add_field(name='Description', value=birthday_girl.description, inline=False)
     embed.add_field(name='Birthday', value=convert_date_to_str(birthday_girl.birthday), inline=False)
     embed.add_field(name='Voice Actor', value=birthday_girl.seiyuu, inline=False)
@@ -150,4 +150,5 @@ def setup(my_bot: commands.Bot) -> None:
     initializer = Initializer()
     my_bot.add_cog(BirthdayCommand(initializer.get_character_repository(),
                                    initializer.get_servers_repository(),
+                                   initializer.get_cdn_url(),
                                    my_bot))

--- a/src/command/birthday/birthday.py
+++ b/src/command/birthday/birthday.py
@@ -14,7 +14,7 @@ from utils.discord_utils import get_discord_color
 
 LOG_ID = "BirthdayCommand"
 
-SCHOOL_ICON_URL = 'https://cdn.starira.xyz/api/assets/jp/res/ui/images/chat/icon_school_{0}.png'
+SCHOOL_ICON_URL = 'https://cdn.karth.top/api/assets/jp/res/ui/images/chat/icon_school_{0}.png'
 
 
 class BirthdayCommand(commands.Cog):

--- a/src/command/initializer.py
+++ b/src/command/initializer.py
@@ -31,7 +31,8 @@ class Initializer(metaclass=Singleton):
 
     def __init__(self):
         self.settings = load_json_file(os.getenv('SETTINGS_PATH', 'settings.json'))
-        self.karthuria_client = KarthuriaClient(self.settings.get('karthuria_api_url'))
+        self.karthuria_client = KarthuriaClient(self.settings.get('karthuria_api_url'),
+                                                self.settings.get("karthuria_cdn_url"))
         self.character_repository = CharacterRepository(self.karthuria_client)
         self.server_repository = ServerRepository(self.settings.get('servers_path'))
         self.event_repository = EventRepository(self.karthuria_client)
@@ -87,3 +88,10 @@ class Initializer(metaclass=Singleton):
         :return: An instance of the Equip Repository
         """
         return self.equip_repository
+
+    def get_cdn_url(self) -> str:
+        """
+        Based on the settings file returns the cdn url that was configured
+        :return A string value
+        """
+        return self.settings.get("karthuria_cdn_url")

--- a/src/karthuria/client.py
+++ b/src/karthuria/client.py
@@ -159,16 +159,17 @@ class KarthuriaClient:
             events_json = response.json()
             if 'event' in events_json:
                 event_info = events_json['event']
-                events = [convert_to_event(event_info[event]) for event in event_info if event_info[event]['info'] != 0]
+                events = [convert_to_event(event_info[event], self.cdn_url) for event in event_info if
+                          event_info[event]['info'] != 0]
                 current_events['events'] = events
             if 'rogue' in events_json:
                 rogue_info = events_json['rogue']
-                challenges = [convert_to_challenge(rogue_info[challenge]) for challenge in rogue_info]
+                challenges = [convert_to_challenge(rogue_info[challenge], self.cdn_url) for challenge in rogue_info]
                 current_events['challenges'] = challenges
             if 'titan' in events_json:
                 titan_info = events_json['titan']
                 boss_end_at = titan_info['endAt']
-                bosses = [convert_to_boss(titan_info['enemy'][boss], boss_end_at) for boss in titan_info['enemy']]
+                bosses = [convert_to_boss(titan_info['enemy'][boss], boss_end_at, self.cdn_url) for boss in titan_info['enemy']]
                 current_events['bosses'] = bosses
 
         return current_events if response.ok else response.raise_for_status()
@@ -244,44 +245,50 @@ def convert_to_enemy(basic_info: dict) -> Enemy:
     return enemy
 
 
-def convert_to_event(event_info: dict) -> Event:
+def convert_to_event(event_info: dict, event_url: str = '') -> Event:
     """
     Transform a dictionary with the 'event' information returned by Karthuria API into a Event object
 
     :param event_info: Information retrieved from the 'event' response
+    :param event_url: Url of the event banner
     :return: A new instance of the Event model with the given information
     """
     event = Event(event_info['id'],
                   end_date=event_info['endAt'][0],
-                  start_date=event_info['beginAt'][0])
+                  start_date=event_info['beginAt'][0],
+                  event_url=event_url)
 
     return event
 
 
-def convert_to_challenge(challenge_info: dict) -> Challenge:
+def convert_to_challenge(challenge_info: dict, challenge_url: str = '') -> Challenge:
     """
     Transform a dictionary with the 'rogue' information returned by Karthuria API into a Challenge object
 
     :param challenge_info: Information retrieved from the 'rogue' response
+    :param challenge_url: Url of the challenge banner
     :return: A new instance of the Challenge model with the given information
     """
     challenge = Challenge(challenge_info['id'],
                           challenge_info['endAt'],
-                          start_date=challenge_info['beginAt'])
+                          start_date=challenge_info['beginAt'],
+                          challenge_url=challenge_url)
 
     return challenge
 
 
-def convert_to_boss(boss_info: dict, end_at: int) -> Boss:
+def convert_to_boss(boss_info: dict, end_at: int, boss_url: str = '') -> Boss:
     """
     Transform a dictionary with the 'titan' and 'enemy' information returned by Karthuria API into a Boss object
 
     :param boss_info: Information retrieved from the 'titan' and 'enemy' response
     :param end_at: End date of the boss battle
+    :param boss_url: Url of the enemy icon
     :return: A new instance of the Boss model with the given information
     """
     boss = Boss(boss_info['id'],
                 end_at,
-                hp_percentage=boss_info['hpLeftPercent'])
+                hp_percentage=boss_info['hpLeftPercent'],
+                boss_url=boss_url)
 
     return boss

--- a/src/karthuria/client.py
+++ b/src/karthuria/client.py
@@ -11,13 +11,15 @@ class KarthuriaClient:
     More information can be found in their web site: https://karth.top/home
     """
 
-    def __init__(self, endpoint: str):
+    def __init__(self, endpoint: str, cdn_url: str):
         """
         Initialize the KarthuriaClient
 
         :param endpoint: Base url to retrieve information from the Karthuria API
+        :param cdn_url: Base url to retrieve assets from the Karthuria CDN
         """
         self.endpoint = endpoint
+        self.cdn_url = cdn_url
 
     def get_characters(self) -> list:
         """
@@ -35,7 +37,7 @@ class KarthuriaClient:
             for character in characters_json:
                 basic_info = characters_json[character]['basicInfo']
                 if basic_info['birth_day'] != 0 and basic_info['school_id'] in schools:
-                    list_of_characters.append(convert_to_character(basic_info))
+                    list_of_characters.append(convert_to_character(basic_info, self.cdn_url))
 
         return list_of_characters if response.ok else response.raise_for_status()
 
@@ -54,7 +56,7 @@ class KarthuriaClient:
             basic_info = character_json['basicInfo']
             info = character_json['info']
 
-        return convert_to_character(basic_info, info) if response.ok else response.raise_for_status()
+        return convert_to_character(basic_info, self.cdn_url, info) if response.ok else response.raise_for_status()
 
     def get_dress(self, dress_id: int) -> Dress:
         """
@@ -172,11 +174,12 @@ class KarthuriaClient:
         return current_events if response.ok else response.raise_for_status()
 
 
-def convert_to_character(basic_info: dict, detailed_info: dict = None) -> Character:
+def convert_to_character(basic_info: dict, portrait_url: str = '', detailed_info: dict = None) -> Character:
     """
     Transform a dictionary with the 'basicInfo' and 'info' information returned by Karthuria API
     into a Character object
 
+    :param portrait_url: The url of the portrait
     :param basic_info: Information retrieved from the 'basicInfo' response
     :param detailed_info: Information retrieved from the 'info' response of detailed character information
     :return: A new instance of the Character model with the given information
@@ -187,6 +190,7 @@ def convert_to_character(basic_info: dict, detailed_info: dict = None) -> Charac
                           basic_info['birth_day'],
                           basic_info['birth_month'],
                           basic_info['school_id'],
+                          portrait_url=portrait_url,
                           detailed_info=detailed_info)
     return character
 

--- a/src/karthuria/model/character.py
+++ b/src/karthuria/model/character.py
@@ -3,20 +3,18 @@ from datetime import datetime
 from karthuria.model.color import Color
 from karthuria.model.school import School
 
-PORTRAIT_URL = 'https://cdn.karth.top/api/assets/jp/res/ui/images/archive/archive_chara/select/chara_portrait_{0}.png'
-
 
 class Character:
     """
     Model class of a Character with the basic information that can be retrieved from the Karthuria API
     """
 
-    def __init__(self, chara_id, name, birth_day, birth_month, school_id, detailed_info=None):
+    def __init__(self, chara_id, name, birth_day, birth_month, school_id, portrait_url='', detailed_info=None):
         self.id = chara_id
         self.name = name
         self.birthday = datetime(1, birth_month, birth_day).strftime('%d/%m')
         self.school = School(school_id)
-        self.portrait = PORTRAIT_URL.format(self.id)
+        self.portrait = '{0}/res/ui/images/archive/archive_chara/select/chara_portrait_{1}.png'.format(portrait_url, self.id)
         self.color = Color(name)
         if detailed_info:
             self.description = detailed_info['introduction']['en']

--- a/src/karthuria/model/event.py
+++ b/src/karthuria/model/event.py
@@ -3,17 +3,15 @@ from datetime import datetime
 
 class Event:
     """
-    Model class of Events information that can be retrieve from Karthuria API
+    Model class of Events information that can be retrieved from Karthuria API
     """
 
-    EVENT_BANNER_URL = 'https://cdn.karth.top/api/assets/ww/res_en/res/event_permanent/banner/event_banner_{0}.png'
-
-    def __init__(self, event_id: int, end_date: int = None, name: str = None, start_date: int = None):
+    def __init__(self, event_id: int, end_date: int = None, name: str = None, start_date: int = None, event_url: str = ''):
         self.event_id = event_id
         self.name = name
         self.start_date = datetime.fromtimestamp(start_date) if start_date is not None else start_date
         self.end_date = datetime.fromtimestamp(end_date) if end_date is not None else end_date
-        self.icon = self.EVENT_BANNER_URL.format(event_id)
+        self.icon = '{0}/res_en/res/event_permanent/banner/event_banner_{1}.png'.format(event_url, event_id)
 
     def set_start_date(self, start_date: int) -> None:
         self.start_date = datetime.fromtimestamp(start_date)
@@ -27,14 +25,13 @@ class Event:
 
 class Challenge(Event):
     """
-    Model class of Challenge information that can be retrieve from Karthuria API
+    Model class of Challenge information that can be retrieved from Karthuria API
     """
 
-    CHALLENGE_ICON_URL = 'https://cdn.karth.top/api/assets/jp/res/item_root/large/1_{0}.png'
-
-    def __init__(self, challenge_id: int, end_date: int, name: str = None, rarity: int = None, start_date: int = None):
+    def __init__(self, challenge_id: int, end_date: int, name: str = None, rarity: int = None, start_date: int = None,
+                 challenge_url: str = ''):
         super().__init__(challenge_id, end_date, name, start_date)
-        self.icon = self.CHALLENGE_ICON_URL.format(challenge_id)
+        self.icon = '{0}/res/item_root/large/1_{1}.png'.format(challenge_url, challenge_id)
         self.rarity = rarity
 
     def set_rarity(self, rarity: int) -> None:
@@ -43,15 +40,15 @@ class Challenge(Event):
 
 class Boss(Event):
     """
-    Model class of Enemy information that can be retrieve from Karthuria API
+    Model class of Enemy information that can be retrieved from Karthuria API
     """
 
-    ENEMY_ICON_URL = 'https://cdn.karth.top/api/assets/jp/res/icon/enemy/{0}.png'
-
-    def __init__(self, boss_id: int, end_date: int, name: str = None, rarity: int = None, hp_percentage: str = None):
+    def __init__(self, boss_id: int, end_date: int, name: str = None, rarity: int = None, hp_percentage: str = None,
+                 boss_url: str = ''):
         super().__init__(boss_id, end_date, name, None)
         self.rarity = rarity
         self.hp_percentage = hp_percentage
+        self.enemy_icon_url = '{0}/{1}'.format(boss_url, 'res/icon/enemy/{0}.png')
 
     def set_rarity(self, rarity: int) -> None:
         self.rarity = rarity
@@ -60,4 +57,4 @@ class Boss(Event):
         self.hp_percentage = hp_percentage
 
     def set_icon(self, icon_id: int):
-        self.icon = self.ENEMY_ICON_URL.format(icon_id)
+        self.icon = self.enemy_icon_url.format(icon_id)

--- a/src/karthuria/repository/event_repository.py
+++ b/src/karthuria/repository/event_repository.py
@@ -18,7 +18,7 @@ class EventRepository:
 
     def get_event_name_by_id(self, event_id: str) -> str:
         """
-        Search for the name of a event based on the given id.
+        Search for the name of an event based on the given id.
 
         :param event_id: Id of the event to search
         :return: The name of the event

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def character():
         'likes': {'en': 'Film/theater, training'},
         'dislikes': {'en': 'Scary stories (esp. Japanese horror films)'},
     }
-    return Character(104, 'Claudine Saijo', 1, 8, 1, detailed_info)
+    return Character(104, 'Claudine Saijo', 1, 8, 1, detailed_info=detailed_info)
 
 
 @pytest.fixture

--- a/tests/karthuria/test_client.py
+++ b/tests/karthuria/test_client.py
@@ -8,7 +8,7 @@ from karthuria.client import KarthuriaClient
 from karthuria.model.color import Color
 from karthuria.model.school import School
 
-client = KarthuriaClient('test_url')
+client = KarthuriaClient('test_url', 'test_cdn_url')
 
 
 class TestGetCharacters:


### PR DESCRIPTION
## CDN Urls as Settings ##
### New ###
- Added a new key in settings called `karthuria_cdn_url ` to make easier the change of url of the CDN

### Changes ###
- Changed `Character` portrait url
- Changed `Birthday` school icon url
- Changed `Event`, `Enemy` and `Challenge` icon url
- Changed All urls of `I Love You` command

### Fixes ###
- This change also fix issue #19 